### PR TITLE
workflows/build: arduino-lint-action update mode.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,7 @@ jobs:
       - uses: arduino/arduino-lint-action@v1
         with:
           compliance: strict
-          # Enable once accepted into library.
-          # library-manager: update
+          library-manager: update
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
Otherwise it will fail now we've been included.